### PR TITLE
QUnit test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ I hope so. But I'll never get all that time spent debugging back.
 ###Does it really work?
 
 See a small Qunit test page on 
-<a href="./clickSuck/blob/master/test/browser.html" target="_blank" 
+<a href="./test/browser.html" target="_blank" 
   title="opens in new tab or window">rawgit</a>.

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ I hope so. But I'll never get all that time spent debugging back.
 ###Does it really work?
 
 See a small Qunit test page on 
-<a href="./test/browser.html" target="_blank" 
-  title="opens in new tab or window">rawgit</a>.
+<a href="https://rawgit.com/dfkaye/clickSuck/master/test/browser.html" 
+  target="_blank" title="opens in new tab or window">raw github</a>.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,22 @@ This totally fixes it.
 
 ###How to use?
 
-Put this in your javascripts
+Include 
 
-	clickSuck.init();
+    <script src='../src/clickSuck.js'></script>
 
-that's it.
+Initialize it in your own JavaScript:
+
+    clickSuck.init();
+
+That's it.
 
 ###Will Safari Ever fix their browser
 
 I hope so. But I'll never get all that time spent debugging back. 
+
+###Does it really work?
+
+See a small Qunit test page on 
+<a href="./clickSuck/blob/master/test/browser.html" target="_blank" 
+  title="opens in new tab or window">rawgit</a>.

--- a/test/browser.html
+++ b/test/browser.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+
+<meta charset='utf-8'>
+<meta name='X-UA-Compatible' content='IE=edge,chrome=1'>
+<meta name='viewport' content='width=device-width, initial-scale=1,maximum-scale=1,user-scalable=no'>
+<meta name='MobileOptimized' content='320'>
+<meta name='HandheldFriendly' content='true'>
+
+<title>clickSuck test | qunit</title>
+<link rel='stylesheet' href='https://code.jquery.com/qunit/qunit-1.18.0.css'>
+
+<div id='qunit'></div>
+<div id='qunit-fixture'></div>
+<script src='https://code.jquery.com/qunit/qunit-1.18.0.js'></script>
+<script src='../src/clickSuck.js'></script>
+<script src='./tests.js'></script>

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,0 +1,51 @@
+/* 
+  clickSuck qunit tests 
+  8 July 2015
+  
+  Verify that clickSuck captures touchend events as click events when environment 
+  supports ontouchstart.
+*/
+
+QUnit.module('clickSuck', {
+    beforeEach: function () {
+      
+      this.touchend = new Event('touchend', {"bubbles": true, cancelable: true});
+      this.click = new Event('click', {"bubbles": true, cancelable: true});
+
+      this.spy = function spy (e) {
+        spy.count += 1;
+      };
+      this.spy.count = 0;
+      
+      document.body.addEventListener('click', this.spy);
+    },
+    afterEach: function () {
+      document.body.removeEventListener('click', this.spy);
+    }
+});
+
+QUnit.test( "does not capture touchend as click when not touchEnabled", function( assert ) {
+  
+  clickSuck.settings.touchEnabled = false;
+  clickSuck.init();
+  
+  document.getElementById('qunit-fixture').dispatchEvent(this.touchend);
+  assert.equal( this.spy.count, 0, 'should not capture touchend' );
+  
+  document.getElementById('qunit-fixture').dispatchEvent(this.click);
+  assert.equal( this.spy.count, 1, 'captures click' );  
+});
+
+QUnit.test( "captures touchend as click when touchEnabled", function( assert ) {
+  
+  clickSuck.settings.touchEnabled = true;
+  clickSuck.init();
+  
+  assert.equal( this.spy.count, 0, 'no events yet');
+  
+  document.getElementById('qunit-fixture').dispatchEvent(this.click);
+  assert.equal( this.spy.count, 1, 'captures click' );
+
+  document.getElementById('qunit-fixture').dispatchEvent(this.touchend);
+  assert.equal( this.spy.count, 2, 'captures touchend as click' );
+});


### PR DESCRIPTION
Added a page that uses a couple of QUnit tests to check out the main claim, that `touchend` events on a touch-enabled environment will be captured (or sucked in) as `click` events.

Also added a link on the README that opens the browser test page on rawgithub ~ you'll need to change the `href` attribute to point to `github.com/tevko` instead of `dfkaye`
